### PR TITLE
Fix warnings and formatting of math blocks

### DIFF
--- a/rst/beginners-guide/000-FAQ_for_Beginners/001-FAQ_for_Beginners.rst
+++ b/rst/beginners-guide/000-FAQ_for_Beginners/001-FAQ_for_Beginners.rst
@@ -6,6 +6,7 @@ FAQ for Beginners
    :glob:
    :hidden:
 
+..
    *
 
 ::

--- a/rst/beginners-guide/002-Introduction/001-Introduction.rst
+++ b/rst/beginners-guide/002-Introduction/001-Introduction.rst
@@ -6,6 +6,7 @@ Introduction
    :glob:
    :hidden:
 
+..
    *
 
 | We’re at the start of a new stage in the information revolution. The

--- a/rst/beginners-guide/004-The_Weird_and_Wonderful_World_of_the_Qubit/001-The_Weird_and_Wonderful_World_of_the_Qubit.rst
+++ b/rst/beginners-guide/004-The_Weird_and_Wonderful_World_of_the_Qubit/001-The_Weird_and_Wonderful_World_of_the_Qubit.rst
@@ -6,6 +6,7 @@ The Weird and Wonderful World of the Qubit
    :glob:
    :hidden:
 
+..
    *
 
 A qubit is a quantum system consisting of two energy levels, labeled

--- a/rst/beginners-guide/006-Multi-Qubit_Gates/001-Multi-Qubit_Gates.rst
+++ b/rst/beginners-guide/006-Multi-Qubit_Gates/001-Multi-Qubit_Gates.rst
@@ -6,6 +6,7 @@ Multi-Qubit Gates
    :glob:
    :hidden:
 
+..
    *
 
 The notation for the state of a machine with multiple qubits is similar

--- a/rst/full-user-guide/000-FAQ/000-Frequently_Asked_Questions.rst
+++ b/rst/full-user-guide/000-FAQ/000-Frequently_Asked_Questions.rst
@@ -6,6 +6,7 @@ Frequently Asked Questions
    :glob:
    :hidden:
 
+..
    *
 
 .. cssclass:: h2
@@ -229,7 +230,7 @@ dilution refrigerator, housed in one of IBM's Quantum Computing labs. 
 A dilution refrigerator is the machine we use to cool down our quantum
 processor device. The refrigerator cools the device down to around 15
 miliKelvin. It works by circulating a mixture of two helium isotopes,
-:math:`^{3}`He and :math:`^{4}`He, in a closed cycle within a complex system
+:math:`^{3}` He and :math:`^{4}` He, in a closed cycle within a complex system
 of pipes and chambers.
 
 **What happens when I hit the "Run" button?**

--- a/rst/full-user-guide/001-The_IBM_Quantum_Experience/003-Quantum_Laws_in_Black_White_and_Blackandwhite.rst
+++ b/rst/full-user-guide/001-The_IBM_Quantum_Experience/003-Quantum_Laws_in_Black_White_and_Blackandwhite.rst
@@ -47,9 +47,6 @@ distinguishable states (2).  
 
        <div style="text-align: left;">
 
-    .. rubric:: 
-       :name: section
-
     #. A Hilbert space is a linear vector space with complex
        coefficients and inner products :math:`\langle \phi|\psi\rangle =
        \sum_i \phi_{i}^{*}\psi_i`.

--- a/rst/full-user-guide/002-The_Weird_and_Wonderful_World_of_the_Qubit/035-Decoherence.rst
+++ b/rst/full-user-guide/002-The_Weird_and_Wonderful_World_of_the_Qubit/035-Decoherence.rst
@@ -21,7 +21,7 @@ Decoherence
 :math:`|\langle X\rangle|^2 +  |\langle Y\rangle|^2 + | \langle Z\rangle|^2 < 1`.
 
 Energy relaxation and :math:`T_1`
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 One important decoherence process is called *energy relaxation*, where
 the excited :math:`|1\rangle` state decays toward the ground state
@@ -35,7 +35,7 @@ gates that do nothing but wait) before measurement causes the state to
 gradually decay towards :math:`|0\rangle`.
 
 Dephasing and :math:`T_2`
-^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 | Dephasing is another decoherence process, and unlike energy
   relaxation, it affects only superposition states. It can be understood

--- a/rst/full-user-guide/003-Multiple_Qubits_Gates_and_Entangled_States/060-GHZ_States.rst
+++ b/rst/full-user-guide/003-Multiple_Qubits_Gates_and_Entangled_States/060-GHZ_States.rst
@@ -2,7 +2,7 @@ GHZ States
 ==========
 
 Perhaps even stranger than Bell states are their three-qubit
-generalization, the \ *GHZ states. *\ An example of one of these states
+generalization, the *GHZ states*. An example of one of these states
 is :math:`\frac{1}{\sqrt{2}}(|000\rangle- |111\rangle)`. The measured
 results should be half :math:`|000\rangle` and half :math:`|111\rangle`. GHZ
 states are named after Greenberger, Horne, and Zeilinger, who were the

--- a/rst/full-user-guide/004-Quantum_Algorithms/070-Grover's_Algorithm.rst
+++ b/rst/full-user-guide/004-Quantum_Algorithms/070-Grover's_Algorithm.rst
@@ -53,11 +53,11 @@ The Oracle
   the oracle matrix :math:`U_f` to act on any of the simple, standard basis
   states :math:`| x \rangle` by
 
-| :math:` U_f | x \rangle = (-1)^{f(x)}  |  x \rangle.`
+| :math:`U_f | x \rangle = (-1)^{f(x)}  |  x \rangle.`
 
 We see that if :math:`x` is an unmarked item, the oracle does nothing to the
-state. However, when we apply the oracle to the basis state :math:` | w
-\rangle `, it maps :math:`U_f | w \rangle = -| w \rangle`.
+state. However, when we apply the oracle to the basis state :math:`| w
+\rangle`, it maps :math:`U_f | w \rangle = -| w \rangle`.
 Geometrically, this unitary matrix corresponds to a reflection about the
 origin for the marked item in an :math:`N = 2^n` dimensional vector space.
 
@@ -69,7 +69,7 @@ have no idea where the marked item is. Therefore, any guess of its
 location is as good as any other, which can be expressed in terms of a
 quantum state called a *uniform superposition*:
 
-:math:` |s \rangle = \frac{1}{\sqrt{N}} \sum_{x = 0}^{N -1} | x
+:math:`|s \rangle = \frac{1}{\sqrt{N}} \sum_{x = 0}^{N -1} | x
 \rangle.`
 
 | If at this point we were to measure in the standard basis :math:`\{ | x
@@ -89,7 +89,7 @@ will return the right item with near-certainty. 
 This algorithm has a nice geometrical interpretation in terms of two
 reflections, which generate a rotation in a two-dimensional plane. The
 only two special states we need to consider are the winner :math:`| w
-\rangle` and the uniform superposition :math:` | s \rangle `. These two
+\rangle` and the uniform superposition :math:`| s \rangle`. These two
 vectors span a two-dimensional plane in the vector space
 :math:`\mathbb{C}^N.` They are not quite perpendicular because :math:`| w
 \rangle` occurs in the superposition with amplitude :math:`N^{-1/2}` as well.
@@ -149,7 +149,7 @@ the winner. 
 | How many times do we need to apply the rotation? It turns out that
   roughly :math:`\sqrt{N}` rotations suffice. This becomes clear when looking
   at the amplitudes of the state :math:`| \psi_t \rangle`. We can see that
-  the amplitude of :math:` | w \rangle` grows linearly with the number of
+  the amplitude of :math:`| w \rangle` grows linearly with the number of
   applications :math:`\sim t N^{-1/2}`. However, since we are dealing with
   amplitudes and not probabilities, the vector space's dimension enters
   as a square root. Therefore it is the amplitude, and not just the

--- a/rst/full-user-guide/004-Quantum_Algorithms/100-Quantum_Phase_Estimation.rst
+++ b/rst/full-user-guide/004-Quantum_Algorithms/100-Quantum_Phase_Estimation.rst
@@ -36,9 +36,9 @@ That is, if we apply the unitary :math:`\exp(- i \hat{p} \lambda)` to some
 wave packet :math:`\psi(x)`, then this wave packet will be shifted by
 :math:`\lambda` in the positive direction.
 
-| The scheme now assumes that we can apply the unitary evolution :math:`
-  \exp(-i H \otimes \hat{p} t )` to both the system and the pointer
-  register as illustrated in the following picture
+| The scheme now assumes that we can apply the unitary evolution
+  :math:`\exp(-i H \otimes \hat{p} t )` to both the system and the
+  pointer register as illustrated in the following picture
 
 | 
 | |image1|\ This picture essentially describes von Neumann"s measurement
@@ -50,16 +50,15 @@ wave packet :math:`\psi(x)`, then this wave packet will be shifted by
   according to the new Hamiltonian :math:`K = H\otimes\hat{p}` for a time
   :math:`t`, so the evolution is given by 
 
-:math:` e^{-it H\otimes \hat{p}} = \sum_{j=1}^{2^N}
-|\psi_{j}\rangle\langle \psi_{j}|\otimes e^{-itE_j \hat{p}}.
-`
+:math:`e^{-it H\otimes \hat{p}} = \sum_{j=1}^{2^N}
+|\psi_{j}\rangle\langle \psi_{j}|\otimes e^{-itE_j \hat{p}}.`
 
 We now observe the action of this measurement apparatus. Suppose that
 :math:`|\psi\rangle` is an
 `eigenstate <https://en.wikipedia.org/wiki/Introduction_to_eigenstates>`__
-:math:`|\psi_{j}\rangle` of :math:`H`, we find that the system evolves to :math:`
-e^{-it H\otimes \hat{p}}|\psi_{j}\rangle|0\rangle =
-|\psi_{j}\rangle |x = tE_j\rangle. ` A measurement of the
+:math:`|\psi_{j}\rangle` of :math:`H`, we find that the system evolves to
+:math:`e^{-it H\otimes \hat{p}}|\psi_{j}\rangle|0\rangle =
+|\psi_{j}\rangle |x = tE_j\rangle.` A measurement of the
 position of the pointer with sufficiently high accuracy will provide an
 approximation to :math:`E_j`.
 
@@ -75,15 +74,16 @@ The quantum algorithm
   :math:`0` through :math:`2^r-1`. In this representation, the discretization of
   the momentum operator becomes
 
-| :math:` \hat{p} = \sum_{j=1}^r 2^{-j}
-  \frac{\mathbb{I}-\sigma^z_j}{2}. `
+| :math:`\hat{p} = \sum_{j=1}^r 2^{-j}
+  \frac{\mathbb{I}-\sigma^z_j}{2}.`
+  xx
 | With this normalization :math:`\hat{p}|z\rangle =
   \frac{z}{2^r}|z\rangle`. Now the discretized Hamiltonian :math:`K =
   H\otimes \hat{p}` is a sum of terms involving at most :math:`k+1`
   qubits, if :math:`H` is a Hamiltonian involving terms of at most :math:`k`
   qubits. Thus we can simulate the dynamics of :math:`K` using standard
   methods. In terms of the momentum eigenbasis the initial (discretized)
-  state of the pointer is written :math:` | x=0\rangle =
+  state of the pointer is written :math:`| x=0\rangle =
   \frac{1}{2^{r/2}}\sum_{z=0}^{2^r-1} |z\rangle`. This state can
   be prepared efficiently on a quantum computer by first initializing
   the qubits of the pointer in the state :math:`|0\rangle \cdots
@@ -93,15 +93,15 @@ The quantum algorithm
   be represented by a product of Hadamard matrices. The discretized
   evolution of the system+pointer now can be written
 
-| :math:`  e^{-it  H\otimes \hat{p}}|\psi_{j}\rangle|x=0\rangle =
+| :math:`e^{-it  H\otimes \hat{p}}|\psi_{j}\rangle|x=0\rangle =
   \frac{1}{2^{r/2}}\sum_{z=0}^{2^r-1} e^{-iE_j
-  zt/2^r}|\psi_{j}\rangle z\rangle. `
+  zt/2^r}|\psi_{j}\rangle z\rangle.`
 
 | Performing an inverse quantum Fourier transform on the pointer leaves
   the system in the state :math:`|\psi_{j}\rangle\otimes|\phi\rangle`,
   where
 
-:math:` | \phi\rangle  = \sum_{x=0}^{2^r-1} \left(
+:math:`| \phi\rangle  = \sum_{x=0}^{2^r-1} \left(
 \frac{1}{2^{r}}\sum_{z=0}^{2^r-1}e^{\frac{2\pi
 i}{2^r}\left(x-\frac{E_j t}{2\pi}\right)z} \right)|x\rangle,`
 

--- a/rst/full-user-guide/004-Quantum_Algorithms/110-Shor's_algorithm.rst
+++ b/rst/full-user-guide/004-Quantum_Algorithms/110-Shor's_algorithm.rst
@@ -180,7 +180,7 @@ functions, a quantum algorithm is allowed to call classical subroutines,
 for example a subroutine for computing the modular multiplication.
 Importantly, before such classical subroutines are incorporated into a
 quantum circuit, they must be transformed into a *reversible
-form. *\ More precisely, a quantum algorithm can call a classical
+form.*\ More precisely, a quantum algorithm can call a classical
 subroutine only if it is compiled into a sequence of reversible logical
 gates such as CNOT or Toffoli gate (in particular, the number of input
 and output wires in each gate must be the same). The subroutine is


### PR DESCRIPTION
* Fix warnings during "make html" due to TOCs for chapters that only
  have one page trying to include non-existing files ("*"), by
  commenting them out so they could be uncommented if the chapter is
  expanded.
* Fix warnings related to unclosed sphinx tags, the majority of them due
  to multi-line tags not ended properly.
* Additionally, fix the display of a number of equations and "math" tags
  where there was an extra space after the backtick (":math:\` X" instead
  of ":math:\`X"), which caused them not to be rendered on the final
  output.

In regards to the "math" tags modified on this PR - as noted on private, those equations seem to be [properly rendered in QE](https://quantumexperience.ng.bluemix.net/qx/tutorial?sectionId=8443c4f713521c10b1a56a533958286b&pageIndex=5) but not when generated [directly using sphinx](https://www.qiskit.org/ibmqx-user-guides/full-user-guide/004-Quantum_Algorithms/100-Quantum_Phase_Estimation.html#the-quantum-algorithm). I'm unsure about the reason, but might be related to the specific version of sphinx (I have used 1.6.3 for these changes) or MathJax used.