### PR TITLE
Remove source link from nav

### DIFF
--- a/theme/theme.conf
+++ b/theme/theme.conf
@@ -45,7 +45,7 @@ navbar_fixed_top = true
 
 # Location of link to source.
 # Options are "nav" (default), "footer" or anything else to exclude.
-source_link_position = nav
+source_link_position =
 
 # Bootswatch (http://bootswatch.com/) theme.
 #


### PR DESCRIPTION
The goal is to drop the `source` link on the HTML version to make it a little friendly on https://quantumexperience.ng.bluemix.net/qx/tutorial?sectionId=beginners-guide&page=introduction.

`Source` link can disturb regular users when they click on it and don't know how to come back again to HTML view.