### PR TITLE
Use travis-sphinx 1.4.4 for deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
 
 install:
     - conda install --yes python="2.7" sphinx
-    - pip install --user travis-sphinx
+    - pip install --user travis-sphinx==1.4.4
 
 script:
     - travis-sphinx --source=rst -n build


### PR DESCRIPTION
Force the version of travis-sphinx to be 1.4.4 instead of the latest
(currently 2.0.1), as it seems to have some subtle differences in the
order of parameters and flags for the executable that cause the build
to break.