### PR TITLE
minor typo fix in .qasm code

### DIFF
--- a/qiskit/openqasm/cnot_00.qasm
+++ b/qiskit/openqasm/cnot_00.qasm
@@ -7,5 +7,5 @@ qreg q[2];
 creg c[2];
 
 // Quantum Circuit
-cx q[0],q[1]
+cx q[0],q[1];
 measure q -> c;

--- a/qiskit/openqasm/cnot_01.qasm
+++ b/qiskit/openqasm/cnot_01.qasm
@@ -8,5 +8,5 @@ creg c[2];
 
 // Quantum Circuit
 x q[0];
-cx q[0],q[1]l
+cx q[0],q[1];
 measure q -> c;


### PR DESCRIPTION
Fix missing semicolon at the end of two statements.